### PR TITLE
Making recordRequests a bool instead of a string

### DIFF
--- a/src/app/imposters/imposter-add.component.html
+++ b/src/app/imposters/imposter-add.component.html
@@ -45,9 +45,9 @@
           <label for='recordFalse'>False</label>  
         </div>
         <div class="col-md-2">
-          <input class='mr-1' type="radio" name='mutualAuth' id='mutualTrue' formControlName="mutualAuth" value="true">
+          <input class='mr-1' type="radio" name='mutualAuth' id='mutualTrue' formControlName="mutualAuth" [value]="true">
           <label for='mutualTrue'>True</label>
-          <input class='ml-2 mr-1' type="radio" name='mutualAuth' id='mutualFalse'  formControlName="mutualAuth" value="false" checked>
+          <input class='ml-2 mr-1' type="radio" name='mutualAuth' id='mutualFalse'  formControlName="mutualAuth" [value]="false" checked>
           <label for='mutualFalse'>False</label>
         </div>
       </div>

--- a/src/app/imposters/imposter-add.component.html
+++ b/src/app/imposters/imposter-add.component.html
@@ -39,9 +39,9 @@
       </div>
       <div class='form-row'>
         <div class='col-md-2 mr-4'>
-          <input class='mr-1' type="radio" name='recordRequests' id='recordTrue' formControlName="recordRequests" value="true">
+          <input class='mr-1' type="radio" name='recordRequests' id='recordTrue' formControlName="recordRequests" [value]="true">
           <label for='recordTrue'>True</label>
-          <input class='ml-2 mr-1' type="radio" name='recordRequests' id='recordFalse'  formControlName="recordRequests" value="false" checked>
+          <input class='ml-2 mr-1' type="radio" name='recordRequests' id='recordFalse'  formControlName="recordRequests" [value]="false" checked>
           <label for='recordFalse'>False</label>  
         </div>
         <div class="col-md-2">

--- a/src/app/imposters/imposter-add.component.ts
+++ b/src/app/imposters/imposter-add.component.ts
@@ -27,7 +27,7 @@ export class ImposterAddComponent implements OnInit {
             recordRequests: false,
             key: '',
             cert: '',
-            mutualAuth: '',
+            mutualAuth: false,
             defaultResponse: [null, [this.validateJson]],
             stubs: [null, [this.validateJson]],
             endOfRequestResolver: [null, [this.validateJson]]

--- a/src/app/imposters/imposter-add.component.ts
+++ b/src/app/imposters/imposter-add.component.ts
@@ -24,7 +24,7 @@ export class ImposterAddComponent implements OnInit {
             port: [null, [Validators.required, Validators.minLength(1)]],
             protocol: [null, [Validators.required, Validators.minLength(1)]],
             name: '',
-            recordRequests: '',
+            recordRequests: false,
             key: '',
             cert: '',
             mutualAuth: '',


### PR DESCRIPTION
Without this, when adding an imposter the `recordRequests` property is being sent to mb as a string, not a boolean. If an empty string is sent mb treats this as `false`, any non-empty string it treats as `true`.

This make for a confusing user experience, when you open the new imposter form neither radio button is selected (which will be sent to mb as an empty string). If the user clicks on True or False a non-empty string will be sent to mb, and the imposter will be created with `recordRequests` set to `true`.

With this change the radio button defaults to False and True/False works as expected.